### PR TITLE
[#19] Delete a blank in an empty line

### DIFF
--- a/src/threads/synch.c
+++ b/src/threads/synch.c
@@ -296,7 +296,7 @@ lock_retrieve ()
 
   if (list_empty (list))
     return priority;
- 
+
   struct list_elem *e;
   for (e = list_begin (list); e != list_end (list); e = list_next (e))
     {


### PR DESCRIPTION
A blank in an empty line in `thread/synch.c` is deleted.