### PR TITLE
[#30] Setting up esp value as PHYS_BASE - 12

### DIFF
--- a/src/userprog/process.c
+++ b/src/userprog/process.c
@@ -438,7 +438,7 @@ setup_stack (void **esp)
     {
       success = install_page (((uint8_t *) PHYS_BASE) - PGSIZE, kpage, true);
       if (success)
-        *esp = PHYS_BASE;
+        *esp = PHYS_BASE - 12; // Temporary measure
       else
         palloc_free_page (kpage);
     }


### PR DESCRIPTION
Setting up esp value as PHYS_BASE -12, as described in Pintos manual.