### PR TITLE
[#5] Validate user virtual address

### DIFF
--- a/src/userprog/syscall.c
+++ b/src/userprog/syscall.c
@@ -6,6 +6,7 @@
 #include "threads/thread.h"
 #include "threads/synch.h"
 #include "threads/init.h"
+#include "threads/vaddr.h"
 
 #define pid_t int
 
@@ -14,10 +15,13 @@
    running a code which must be executed in mutually exclueded state. */
 static struct lock sys_lock;
 
+static int get_byte (const uint8_t *uaddr);
+static bool put_byte (uint8_t *udst, uint8_t byte);
+static uint32_t get_word (const uint32_t *uaddr);
+
 static void syscall_handler (struct intr_frame *);
 
 static void syscall_halt (void);
-static void syscall_exit (int status);
 static pid_t syscall_exec (const char *cmd_line);
 static int syscall_wait (pid_t pid);
 static bool syscall_create (const char *file, unsigned init_size);
@@ -37,53 +41,106 @@ syscall_init (void)
   intr_register_int (0x30, 3, INTR_ON, syscall_handler, "syscall");
 }
 
+/* Reads a byte at user virtual address UADDR.
+   Returns the byte value if successful, -1 if a segfault
+   occured or UADDR is not in the user space. */
+static int
+get_byte (const uint8_t *uaddr)
+{
+  if (!is_user_vaddr (uaddr))
+    return -1;
+  int result;
+  asm ("movl $1f, %0; movzbl %1, %0; 1:"
+       : "=&a" (result) : "m" (*uaddr));
+  return result;
+}
+
+/* Writes BYTE to user address UDST.
+   Returns true if successful, false if a segfault occured
+   or UDST is not in the user space. */
+static bool
+put_byte (uint8_t *udst, uint8_t byte)
+{
+  if (!is_user_vaddr (udst))
+    return false;
+  int error_code;
+  asm ("movl $1f, %0; movb %b2, %1; 1:"
+       : "=&a" (error_code), "=m" (*udst) : "q" (byte));
+  return error_code != -1;
+}
+
+/* Reads a word at user virtual address ADDR.
+   Returns the word value if successful, calls exit system
+   call if not. */
+static uint32_t
+get_word (const uint32_t *uaddr)
+{
+  uint32_t res;
+  int byte;
+  int i;
+  for (i = 0; i < 4; i++)
+    {
+      byte = get_byte ((uint8_t *) uaddr + i);
+      if (byte == -1)
+        syscall_exit (-1);
+      *((uint8_t *) &res + i) = (uint8_t) byte;
+    }
+  return res;
+}
+
 /* Handler which matches appropriate handler to system calls.
    Dispatching handlers with arguments they need. */
 static void
 syscall_handler (struct intr_frame *f UNUSED) 
 {
-  uintptr_t *esp = f->esp;
+  uint32_t *esp = f->esp;
 
-  switch (*esp)
+  switch (get_word (esp))
     {
     case SYS_HALT:
       syscall_halt ();
       break;
     case SYS_EXIT:
-      syscall_exit ((int) *(esp + 1));
+      syscall_exit ((int) get_word (esp + 1));
       break;
     case SYS_EXEC:
-      f->eax = syscall_exec ((const char *) *(esp + 1));
+      f->eax = syscall_exec ((const char *) get_word (esp + 1));
       break;
     case SYS_WAIT:
-      f->eax = syscall_wait ((pid_t) *(esp + 1));
+      f->eax = syscall_wait ((pid_t) get_word (esp + 1));
       break;
     case SYS_CREATE:
-      f->eax = syscall_create ((const char *) *(esp + 1), (unsigned) *(esp + 2));
+      f->eax = syscall_create ((const char *) get_word (esp + 1),
+                               (unsigned) get_word (esp + 2));
       break;
     case SYS_REMOVE:
-      f->eax = syscall_remove ((const char *) *(esp + 1));
+      f->eax = syscall_remove ((const char *) get_word (esp + 1));
       break;
     case SYS_OPEN:
-      f->eax = syscall_open ((const char *) *(esp + 1));
+      f->eax = syscall_open ((const char *) get_word (esp + 1));
       break;
     case SYS_FILESIZE:
-      f->eax = syscall_filesize ((int) *(esp + 1));
+      f->eax = syscall_filesize ((int) get_word (esp + 1));
       break;
     case SYS_READ:
-      f->eax = syscall_read ((int) *(esp + 1), (void *) *(esp + 2), (unsigned) *(esp + 3));
+      f->eax = syscall_read ((int) get_word (esp + 1),
+                             (void *) get_word (esp + 2),
+                             (unsigned) get_word (esp + 3));
       break;
     case SYS_WRITE:
-      f->eax = syscall_write ((int) *(esp + 1), (void *) *(esp + 2), (unsigned) *(esp + 3));
+      f->eax = syscall_write ((int) get_word (esp + 1),
+                              (void *) get_word (esp + 2),
+                              (unsigned) get_word (esp + 3));
       break;
     case SYS_SEEK:
-      syscall_seek ((int) *(esp + 1), (unsigned) *(esp + 2));
+      syscall_seek ((int) get_word (esp + 1),
+                    (unsigned) get_word (esp + 2));
       break;
     case SYS_TELL:
-      f->eax = syscall_tell ((int) *(esp + 1));
+      f->eax = syscall_tell ((int) get_word (esp + 1));
       break;
     case SYS_CLOSE:
-      syscall_close ((int) *(esp + 1));
+      syscall_close ((int) get_word (esp + 1));
       break;
     default:
       thread_exit ();
@@ -98,7 +155,7 @@ syscall_halt (void)
   NOT_REACHED ();
 }
 
-static void 
+void
 syscall_exit (int status)
 {
   printf ("%s: exit(%d)\n", thread_current ()->name, status);

--- a/src/userprog/syscall.h
+++ b/src/userprog/syscall.h
@@ -2,5 +2,6 @@
 #define USERPROG_SYSCALL_H
 
 void syscall_init (void);
+void syscall_exit (int);
 
 #endif /* userprog/syscall.h */


### PR DESCRIPTION
# See #5.

Now system call checks user's given address by using page fault. `get_byte()` and `put_byte()` are given in the manual.

For a temporary measure, two basic system call `exit()` and `write()` are implemented minimaly. `exit()` does not care about the process hierarchy, but only triggers thread termination process after printing given termination message. `write()` does not care about file descriptor, except the standard output. These features should be improved later.