### PR TITLE
[#94] Delete declaration of pid_t in syscall.c

### DIFF
--- a/src/userprog/syscall.c
+++ b/src/userprog/syscall.c
@@ -11,8 +11,7 @@
 #include "threads/synch.h"
 #include "threads/thread.h"
 #include "threads/vaddr.h"
-
-#define pid_t int
+#include "userprog/process.h"
 
 /* A Lock for mutual exclusion between system calls. */
 static struct lock filesys_lock;


### PR DESCRIPTION
See #94.